### PR TITLE
Fixed dependence

### DIFF
--- a/images/php-apache/Dockerfile
+++ b/images/php-apache/Dockerfile
@@ -2,7 +2,7 @@ FROM php:5-apache
 
 RUN a2enmod rewrite
 
-RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libpq-dev \
+RUN apt-get update && apt-get install -y libpng-dev libjpeg-dev libpq-dev \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
   && docker-php-ext-install gd mbstring pdo pdo_mysql pdo_pgsql zip exif


### PR DESCRIPTION
libpng12-dev --> libpng-dev

The package libpng12-dev was dropped after 16.04. 

More info: https://askubuntu.com/questions/991706/e-package-libpng12-dev-has-no-installation-candidate